### PR TITLE
add ember-cli-babel to avoid deprecation warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
   },
   "author": "",
   "license": "MIT",
+  "dependencies": {
+    "ember-cli-babel": "^6.8.2"
+  },
   "devDependencies": {
     "broccoli-asset-rev": "^2.0.0",
     "broccoli-ember-hbs-template-compiler": "^1.6.1",


### PR DESCRIPTION
Get rid of deprecation warning

![image](https://user-images.githubusercontent.com/7160913/32508612-cc4cd23e-c3e2-11e7-9775-7793c212355c.png)
